### PR TITLE
CE Scrolled down case fix

### DIFF
--- a/hash_drop.json
+++ b/hash_drop.json
@@ -15,6 +15,7 @@
         "name": "不夜の薔薇",
         "name_eng": "Nightless Rose",
         "phash": "0b0abe94fefcf566",
+        "phash_narrow": "096a1c07fab5fc7a",
         "dropPriority": 9005
     },
     {
@@ -24,6 +25,7 @@
         "name": "ムーンライト・フェスト",
         "name_eng": "Moonlight Fest",
         "phash": "d77118b930b8ffef",
+        "phash_narrow": "d750880330707ff1",
         "dropPriority": 9005
     },
     {
@@ -33,6 +35,7 @@
         "name": "ハロウィン・プリンセス",
         "name_eng": "Halloween Princess",
         "phash": "e9b80e24de74f4f4",
+        "phash_narrow": "e9f8248fcfe3f87c",
         "dropPriority": 9005
     },
     {
@@ -42,6 +45,7 @@
         "name": "ぐだお",
         "name_eng": "GUDA-O",
         "phash": "dc0d0390621d9420",
+        "phash_narrow": "9c2b11e2638400a4",
         "dropPriority": 9005
     },
     {
@@ -51,6 +55,7 @@
         "name": "ホーリーナイト・サイン",
         "name_eng": "Holy Night Sign",
         "phash": "a9e8c04e4eca7672",
+        "phash_narrow": "a8a8645ec84e02ae",
         "dropPriority": 9005
     },
     {
@@ -60,6 +65,7 @@
         "name": "ピュアリー・ブルーム",
         "name_eng": "Purely Bloom",
         "phash": "f41b3a25f09206e6",
+        "phash_narrow": "d41b2decb9265c50",
         "dropPriority": 9005
     },
     {
@@ -69,6 +75,7 @@
         "name": "アルトリアの星",
         "name_eng": "Star of Altria",
         "phash": "adb2d1ba32537c6d",
+        "phash_narrow": "adf0d9ac93b252b3",
         "dropPriority": 9005
     },
     {
@@ -78,6 +85,7 @@
         "name": "メルティ・スイートハート",
         "name_eng": "Melty Sweetheart",
         "phash": "0ee3124c79748d4c",
+        "phash_narrow": "8fe316ca32715885",
         "dropPriority": 9005
     },
     {
@@ -87,6 +95,7 @@
         "name": "首切りバニー2016",
         "name_eng": "Decapitating Bunny 2018",
         "phash": "7c3c436191c1b54c",
+        "phash_narrow": "3c1e470d91238c33",
         "dropPriority": 9005
     },
     {
@@ -96,6 +105,7 @@
         "name": "三重結界",
         "name_eng": "Threefold Barrier",
         "phash": "f89d380ba7726927",
+        "phash_narrow": "d8b4582592e00f2e",
         "dropPriority": 9005
     },
     {
@@ -105,6 +115,7 @@
         "name": "カルデアの顕学",
         "name_eng": "The Scholars of Chaldea",
         "phash": "38232f0199f7407c",
+        "phash_narrow": "3833078db7c34be9",
         "dropPriority": 9005
     },
     {
@@ -114,6 +125,7 @@
         "name": "カルデアを導く乙女",
         "name_eng": "Maiden Leading Chaldea",
         "phash": "935accb69366aff2",
+        "phash_narrow": "135bac9164cee3f6",
         "dropPriority": 9005
     },
     {
@@ -123,6 +135,7 @@
         "name": "慈悲無き者",
         "name_eng": "The Merciless One",
         "phash": "a623811fecf1298c",
+        "phash_narrow": "a621030ef32d8d9b",
         "dropPriority": 9005
     },
     {
@@ -132,6 +145,7 @@
         "name": "至るべき場所",
         "name_eng": "His Rightful Place",
         "phash": "ccf9c0429e2f4a96",
+        "phash_narrow": "ccb941d22d6b1c3e",
         "dropPriority": 9005
     },
     {
@@ -141,6 +155,7 @@
         "name": "遮那王流離譚",
         "name_eng": "The Wandering Tales of Shana-oh",
         "phash": "0a4771f9938e8c0c",
+        "phash_narrow": "0a477979b38bc400",
         "dropPriority": 9005
     },
     {
@@ -150,6 +165,7 @@
         "name": "ゴールデン捕鯉魚図",
         "name_eng": "Golden Captures the Carp",
         "phash": "cbdf0539a22c7aba",
+        "phash_narrow": "ca8e15f6246dac7a",
         "dropPriority": 9005
     },
     {
@@ -159,6 +175,7 @@
         "name": "風雲仙姫",
         "name_eng": "Divine Princess of the Storm",
         "phash": "56d998b64068cd76",
+        "phash_narrow": "46d99e166ac9db61",
         "dropPriority": 9005
     },
     {
@@ -168,6 +185,7 @@
         "name": "九首牛魔羅王",
         "name_eng": "Ox-Demon King",
         "phash": "19d59587b196813a",
+        "phash_narrow": "595d877934c373a6",
         "dropPriority": 9005
     },
     {
@@ -177,6 +195,7 @@
         "name": "ゴールデン相撲～岩場所～",
         "name_eng": "Golden Sumo: Boulder Tournament",
         "phash": "f362319f4b6bcb8b",
+        "phash_narrow": "f7623496765222bf",
         "dropPriority": 9005
     },
     {
@@ -186,6 +205,7 @@
         "name": "月の湯治",
         "name_eng": "Hot Spring Under the Moon",
         "phash": "a57c1a0f75926eb0",
+        "phash_narrow": "a4d80a65904fb796",
         "dropPriority": 9005
     },
     {
@@ -195,6 +215,7 @@
         "name": "サマータイム・ミストレス",
         "name_eng": "Summertime Mistress",
         "phash": "2f1aeee6c814d6ec",
+        "phash_narrow": "1e18e6ca0d46efb9",
         "dropPriority": 9005
     },
     {
@@ -204,6 +225,7 @@
         "name": "カルデア・ライフセーバーズ",
         "name_eng": "Chaldea Lifesavers",
         "phash": "e160f2f3e21efe76",
+        "phash_narrow": "e120bbe1cbdd75ff",
         "dropPriority": 9005
     },
     {
@@ -213,6 +235,7 @@
         "name": "ジョイント・リサイタル",
         "name_eng": "Joint Recital",
         "phash": "e38832f6b17b1db2",
+        "phash_narrow": "e7824eb4f39df354",
         "dropPriority": 9005
     },
     {
@@ -222,6 +245,7 @@
         "name": "勇者エリちゃんの冒険",
         "name_eng": "Hero Elly's Adventure",
         "phash": "9af7e1021f5b5980",
+        "phash_narrow": "3af7e0a71f592214",
         "dropPriority": 9005
     },
     {
@@ -231,6 +255,7 @@
         "name": "スイート・クリスタル",
         "name_eng": "Sweet Crystal",
         "phash": "f97ec69cf6e76cde",
+        "phash_narrow": "b976099ce77ccef4",
         "dropPriority": 9005
     },
     {
@@ -240,6 +265,7 @@
         "name": "聖夜の晩餐",
         "name_eng": "Holy Night Supper",
         "phash": "6b4ab4e3d9a61996",
+        "phash_narrow": "4b5ee4db6659c631",
         "dropPriority": 9005
     },
     {
@@ -249,6 +275,7 @@
         "name": "フォンダン・オ・ショコラ",
         "name_eng": "Fondant au Chocolat",
         "phash": "8e3473c386078078",
+        "phash_narrow": "8c3c5bf81fa4f907",
         "dropPriority": 9005
     },
     {
@@ -258,6 +285,7 @@
         "name": "日輪の城",
         "name_eng": "Fortress of the Sun",
         "phash": "157105cdc9eeebf3",
+        "phash_narrow": "353105dd8ceaf3a5",
         "dropPriority": 9005
     },
     {
@@ -267,6 +295,7 @@
         "name": "壬生狼",
         "name_eng": "Wolves of Mibu",
         "phash": "e0261a369f076122",
+        "phash_narrow": "e00632de9e53cd45",
         "dropPriority": 9005
     },
     {
@@ -276,6 +305,7 @@
         "name": "いつかの夏",
         "name_eng": "One Summer",
         "phash": "42299b518d2529b4",
+        "phash_narrow": "42ab53914d498515",
         "dropPriority": 9005
     },
     {
@@ -285,6 +315,7 @@
         "name": "シーサイド・ラグジュアリー",
         "name_eng": "Seaside Luxury",
         "phash": "1787297a9cf8d9fe",
+        "phash_narrow": "478769361c1b3ee9",
         "dropPriority": 9005
     },
     {
@@ -294,6 +325,7 @@
         "name": "ダイブ・トゥ・ブルー",
         "name_eng": "Dive to Blue",
         "phash": "2b17d8e23dd97453",
+        "phash_narrow": "231ff022c9b4c9d9",
         "dropPriority": 9005
     },
     {
@@ -303,6 +335,7 @@
         "name": "チア・フォー・マスター",
         "name_eng": "Cheer for Master",
         "phash": "9963709e944be3b1",
+        "phash_narrow": "99635c9c4dc6f859",
         "dropPriority": 9005
     },
     {
@@ -312,6 +345,7 @@
         "name": "エアリアル・ドライブ",
         "name_eng": "Aerial Drive",
         "phash": "bc86d368aad144e4",
+        "phash_narrow": "3c96452e9b5bc400",
         "dropPriority": 9005
     },
     {
@@ -321,6 +355,7 @@
         "name": "メリー・シープ",
         "name_eng": "Merry Sheep",
         "phash": "690ae169db925e73",
+        "phash_narrow": "69026d79b0bffbe6",
         "dropPriority": 9005
     },
     {
@@ -331,6 +366,7 @@
         "name_eng": "Sweet Days",
         "shortname": "礼装",
         "phash": "0382eee6d7fdf9fe",
+        "phash_narrow": "01a2eec7f7f9f8de",
         "dropPriority": 9005
     },
     {
@@ -340,6 +376,7 @@
         "name": "トゥリファスにて",
         "name_eng": "At Trifas",
         "phash": "c0199fe61b7ca64e",
+        "phash_narrow": "c119cdd379b39f27",
         "dropPriority": 9005
     },
     {
@@ -349,6 +386,7 @@
         "name": "城塞の午後",
         "name_eng": "An Afternoon at the Fortress",
         "phash": "0a1dd97266339140",
+        "phash_narrow": "0a1df14c2d904d30",
         "dropPriority": 9005
     },
     {
@@ -358,6 +396,7 @@
         "name": "白い服の水兵さん",
         "name_eng": "The Sailor in White",
         "phash": "923824193d8b9d2d",
+        "phash_narrow": "d3e6707843ab3351",
         "dropPriority": 9005
     },
     {
@@ -367,6 +406,7 @@
         "name": "ペインティング・サマー",
         "name_eng": "Painting Summer",
         "phash": "7776c4192c26ff73",
+        "phash_narrow": "73d6d09804ef167d",
         "dropPriority": 9005
     },
     {
@@ -376,6 +416,7 @@
         "name": "レディ・フォクシー",
         "name_eng": "Foxy Lady",
         "phash": "95fac2f7bfb442ce",
+        "phash_narrow": "9deac24fb1b0ce56",
         "dropPriority": 9005
     },
     {
@@ -385,6 +426,7 @@
         "name": "ウォーター・シャイン",
         "name_eng": "Water Shine",
         "phash": "777c930f46c3dc4d",
+        "phash_narrow": "76f0bb2ea2d24d82",
         "dropPriority": 9005
     },
     {
@@ -394,6 +436,7 @@
         "name": "リターン・マッチ",
         "name_eng": "Grudge Match",
         "phash": "88bb085eb44bd286",
+        "phash_narrow": "8b3b58b619d0a64f",
         "dropPriority": 9005
     },
     {
@@ -403,6 +446,7 @@
         "name": "C・K・T",
         "name_eng": "C.K.T.",
         "phash": "6cc9886271626336",
+        "phash_narrow": "7d8d88b8d5cb8a83",
         "dropPriority": 9005
     },
     {
@@ -411,6 +455,7 @@
         "rarity": 5,
         "name": "ロイヤル・アイシング",
         "phash": "b6951667a6b90864",
+        "phash_narrow": "ba9c5126939b061e",
         "dropPriority": 9005
     },
     {
@@ -419,6 +464,7 @@
         "rarity": 5,
         "name": "スリー・アングラー",
         "phash": "fd872466f861796b",
+        "phash_narrow": "fd998686b4b43677",
         "dropPriority": 9005
     },
     {
@@ -427,6 +473,7 @@
         "rarity": 5,
         "name": "氷結闘熊",
         "phash": "d1dced638e32dd2e",
+        "phash_narrow": "d1dcf5c6b3550ee3",
         "dropPriority": 9005
     },
     {
@@ -436,6 +483,7 @@
         "name": "聖女の教示",
         "shortname": "礼装",
         "phash": "2a067dcd4909b27b",
+        "phash_narrow": "2a16f7ed0c8557f6",
         "dropPriority": 9005
     },
     {
@@ -444,6 +492,7 @@
         "rarity": 5,
         "name": "銀雪の女神たち",
         "phash": "32f6d67adf51c4ac",
+        "phash_narrow": "28a6646a53d0f764",
         "dropPriority": 9005
     },
     {
@@ -453,6 +502,7 @@
         "name": "ビューティフル・ドリーマー",
         "shortname": "礼装",
         "phash": "ba376d42d90a0152",
+        "phash_narrow": "bab76dd12c036409",
         "dropPriority": 9005
     },
     {
@@ -462,6 +512,7 @@
         "name": "錦上添花",
         "shortname": "礼装",
         "phash": "07f01e06310ea172",
+        "phash_narrow": "a7f80e731fa69193",
         "dropPriority": 9005
     },
     {
@@ -471,6 +522,7 @@
         "name": "次期当主会議",
         "shortname": "礼装",
         "phash": "4887d7a5b5780f12",
+        "phash_narrow": "4847c7a5f1a952ce",
         "dropPriority": 9005
     },
     {
@@ -479,6 +531,7 @@
         "rarity": 5,
         "name": "腹が減っては戦ができぬ",
         "phash": "9ded991269d7ec1c",
+        "phash_narrow": "8dcd9a3153e01c97",
         "dropPriority": 9005
     },
     {
@@ -487,6 +540,7 @@
         "rarity": 5,
         "name": "天鬼姫",
         "phash": "09e0e89ef69ce7ec",
+        "phash_narrow": "19e008ffbefdf8f5",
         "dropPriority": 9005
     },
     {
@@ -495,6 +549,7 @@
         "rarity": 5,
         "name": "盛夏の思い出",
         "phash": "4fc4957d7df2e27d",
+        "phash_narrow": "4f84a57d5483b47a",
         "dropPriority": 9005
     },
     {
@@ -504,6 +559,7 @@
         "name": "シーニック・ビューティー",
         "shortname": "礼装",
         "phash": "1b79c9ca1953c136",
+        "phash_narrow": "1a39cdae19d91f03",
         "dropPriority": 9005
     },
     {
@@ -513,6 +569,7 @@
         "name": "双つ星の歌姫",
         "shortname": "礼装",
         "phash": "a1f8acadba8f66cc",
+        "phash_narrow": "b138e5f82b274945",
         "dropPriority": 9005
     },
     {
@@ -522,6 +579,7 @@
         "name": "ベスティア・デル・ソル",
         "shortname": "礼装",
         "phash": "d238c76e84633cce",
+        "phash_narrow": "3299678c237366b0",
         "dropPriority": 9005
     },
     {
@@ -531,6 +589,7 @@
         "name": "クリスマスの軌跡",
         "shortname": "礼装",
         "phash": "8d34a0fcd5c4f7d8",
+        "phash_narrow": "ad2528bd85fff8f7",
         "dropPriority": 9005
     },
     {
@@ -540,6 +599,7 @@
         "name": "ニット・ザ・ラブ",
         "shortname": "礼装",
         "phash": "cfcc6cfafe69a7fa",
+        "phash_narrow": "c70ce8de5daf76d7",
         "dropPriority": 9005
     },
     {
@@ -549,6 +609,7 @@
         "name": "見上げた空の星に",
         "shortname": "礼装",
         "phash": "872899e2f9529df5",
+        "phash_narrow": "8738aee9dbdc653d",
         "dropPriority": 9005
     },
     {
@@ -558,6 +619,7 @@
         "name": "ハイド・ハンター",
         "shortname": "礼装",
         "phash": "a1fc07eb5a7b3d69",
+        "phash_narrow": "a1b5a7ce1ab86dfc",
         "dropPriority": 9005
     },
     {
@@ -567,6 +629,7 @@
         "name": "チェーンソー・オブ・ザ・デッド",
         "shortname": "礼装",
         "phash": "98d04fcdb93b5bde",
+        "phash_narrow": "b912c7ed2973de5f",
         "dropPriority": 9005
     },
     {
@@ -576,6 +639,7 @@
         "name": "カレイドサファイア",
         "name_eng": "Kaleid Sapphire",
         "phash": "96e9e3846bfc1063",
+        "phash_narrow": "96eb9043ef986b2e",
         "dropPriority": 9004
     },
     {
@@ -585,6 +649,7 @@
         "name": "カレイドルビー",
         "name_eng": "Kaleid Ruby",
         "phash": "6178ceeed634f1ab",
+        "phash_narrow": "6159ceca1cd3d7dc",
         "dropPriority": 9004
     },
     {
@@ -594,6 +659,7 @@
         "name": "ウィザード＆プリースト",
         "name_eng": "Wizard & Priest",
         "phash": "a9a3610ccaea72fe",
+        "phash_narrow": "a9a36d0ecfa2ef7d",
         "dropPriority": 9004
     },
     {
@@ -603,6 +669,7 @@
         "name": "黄金の翼",
         "name_eng": "Golden Wings",
         "phash": "61e29d2df2d76bb7",
+        "phash_narrow": "61921d38dcabdde6",
         "dropPriority": 9004
     },
     {
@@ -612,6 +679,7 @@
         "name": "概念礼装EXPカード：ノッブ",
         "name_eng": "CE EXP Card: Nobbu",
         "phash": "3e27cc2ba1380d46",
+        "phash_narrow": "36b54ce3b0292600",
         "dropPriority": 9004
     },
     {
@@ -621,6 +689,7 @@
         "name": "概念礼装EXPカード：謎の物質α",
         "name_eng": "CE EXP Card: Mysterious Substance α",
         "phash": "bc5d99130d024142",
+        "phash_narrow": "faf9181f0e1f0001",
         "dropPriority": 9004
     },
     {
@@ -630,6 +699,7 @@
         "name": "概念礼装EXPカード：ぐだぐだ明治維新",
         "name_eng": "CE EXP Card: GUDAGUDA Meiji Restoration",
         "phash": "d70cb5336cf2e3f8",
+        "phash_narrow": "d78c333c246364fb",
         "dropPriority": 9004
     },
     {
@@ -639,6 +709,7 @@
         "name": "概念礼装EXPカード：ＢＢショット！",
         "name_eng": "CE EXP Card: BB Shot!",
         "phash": "625e2a05f3c85738",
+        "phash_narrow": "c65e0b37c9473077",
         "dropPriority": 9004
     },
     {
@@ -648,6 +719,7 @@
         "name": "概念礼装EXPカード：宇宙犬",
         "name_eng": "CE EXP Card: Dogs in Space",
         "phash": "4f629c3efde6a192",
+        "phash_narrow": "43803c7cfeecd4eb",
         "dropPriority": 9004
     },
     {
@@ -657,6 +729,7 @@
         "name": "概念礼装EXPカード：フランの花",
         "name_eng": "CE EXP Card: Fran's Flower",
         "phash": "4647c7a19930efe5",
+        "phash_narrow": "36474789115cb629",
         "dropPriority": 9004
     },
     {
@@ -666,6 +739,7 @@
         "name": "概念礼装EXPカード：ぐだぐだまじんさん",
         "name_eng": "CE EXP Card: GUDAGUDA Miss Majin",
         "phash": "465358ae99524f26",
+        "phash_narrow": "8653f0a510db0a1b",
         "dropPriority": 9004
     },
     {
@@ -675,6 +749,7 @@
         "name": "概念礼装EXPカード：ドルセント・ショップ",
         "name_eng": "CE EXP Card: Moolah's Shop",
         "phash": "3ce3cbd2b0323953",
+        "phash_narrow": "2cefced68620c042",
         "dropPriority": 9004
     },
     {
@@ -683,6 +758,7 @@
         "rarity": 4,
         "name": "概念礼装EXPカード：猪王",
         "phash": "7261b137c9c58836",
+        "phash_narrow": "6661327d49897616",
         "dropPriority": 9004
     },
     {
@@ -691,6 +767,7 @@
         "rarity": 4,
         "name": "概念礼装EXPカード：ぐだぐだ天魔王×３",
         "phash": "5a03e4f2195eac73",
+        "phash_narrow": "5a87e4f109bc316f",
         "dropPriority": 9004
     },
     {
@@ -700,6 +777,7 @@
         "name": "概念礼装EXPカード：はじめてのカレー",
         "shortname": "★4EXP礼装",
         "phash": "3f00f85e67aea3a2",
+        "phash_narrow": "3f60d8541eed6952",
         "dropPriority": 9004
     },
     {
@@ -708,6 +786,7 @@
         "rarity": 4,
         "name": "概念礼装EXPカード：窮鼠",
         "phash": "694287995a63e689",
+        "phash_narrow": "6966879c716688b3",
         "dropPriority": 9004
     },
     {
@@ -717,6 +796,7 @@
         "name": "トリック・オア・トリート",
         "name_eng": "Trick or Treat",
         "phash": "9df0ccbc30d3e4d5",
+        "phash_narrow": "bf40ccbc13e9f0da",
         "dropPriority": 9003
     },
     {
@@ -726,6 +806,7 @@
         "name": "概念礼装EXPカード：マジカルルビー",
         "name_eng": "CE EXP Card: Magical Ruby",
         "phash": "3ee132a57a6d729d",
+        "phash_narrow": "4fd322946c23ccf0",
         "dropPriority": 9003
     },
     {
@@ -735,6 +816,7 @@
         "name": "マタ・ハリの酒場",
         "name_eng": "Mata Hari's Tavern",
         "phash": "3d65f0c693926edb",
+        "phash_narrow": "3d6df4c1903693f0",
         "dropPriority": 9003
     },
     {
@@ -744,6 +826,7 @@
         "name": "ノスタルジック・フォーム",
         "name_eng": "Nostalgic Form",
         "phash": "a5933f4163006952",
+        "phash_narrow": "a493bd43a60d270c",
         "dropPriority": 9003
     },
     {
@@ -753,6 +836,7 @@
         "name": "概念礼装EXPカード：おき太",
         "name_eng": "CE EXP Card: Okita",
         "phash": "e10997441e7f77f0",
+        "phash_narrow": "e18987185b37dc1d",
         "dropPriority": 9003
     },
     {
@@ -762,6 +846,7 @@
         "name": "概念礼装EXPカード：謎の物質β",
         "name_eng": "CE EXP Card: Mysterious Substance β",
         "phash": "ee5d353b528528c3",
+        "phash_narrow": "ce552d522439c020",
         "dropPriority": 9003
     },
     {
@@ -771,6 +856,7 @@
         "name": "概念礼装EXPカード：九字兼定",
         "name_eng": "CE EXP Card: Kuji Kanesada",
         "phash": "dbe1c30b969428db",
+        "phash_narrow": "7af1c30b9528c321",
         "dropPriority": 9003
     },
     {
@@ -780,6 +866,7 @@
         "name": "概念礼装EXPカード：刻印虫",
         "name_eng": "CE EXP Card: Crest Worms",
         "phash": "a163e6ca66dadbf1",
+        "phash_narrow": "b167cd6fe68aedb7",
         "dropPriority": 9003
     },
     {
@@ -789,6 +876,7 @@
         "name": "概念礼装EXPカード：ぐだぐだウェルカム",
         "name_eng": "CE EXP Card: GUDAGUDA Recruitment",
         "phash": "ce6565f909c69566",
+        "phash_narrow": "8a67f70928994e48",
         "dropPriority": 9003
     },
     {
@@ -798,6 +886,7 @@
         "name": "概念礼装EXPカード：ぐだぐだ土佐同盟",
         "name_eng": "CE EXP Card: GUDAGUDA Tosa Alliance",
         "phash": "44570f866c6fe22a",
+        "phash_narrow": "d4f3839445840e56",
         "dropPriority": 9003
     },
     {
@@ -806,6 +895,7 @@
         "rarity": 3,
         "name": "概念礼装EXPカード：毘沙門天ぞ是にあり！",
         "phash": "045bfac47960143e",
+        "phash_narrow": "047bdece41d02ec1",
         "dropPriority": 9003
     },
     {
@@ -815,6 +905,7 @@
         "name": "概念礼装EXPカード：謎の物質γ",
         "shortname": "★3EXP礼装",
         "phash": "89f4cc1c9e3e35e9",
+        "phash_narrow": "a1e4edce1e0f05fd",
         "dropPriority": 9003
     },
     {

--- a/update.py
+++ b/update.py
@@ -217,7 +217,20 @@ def compute_hash_ce(img_rgb):
     記述した比率はiPpd2018画像の実測値
     """
     height, width = img_rgb.shape[:2]
-    img = img_rgb[19:115,3:119]
+    img = img_rgb[5:115,3:119]
+
+##    cv2.imshow("img", cv2.resize(img, dsize=None, fx=2., fy=2.))
+##    cv2.waitKey(0)
+##    cv2.destroyAllWindows()
+    return hasher.compute(img)
+
+def compute_hash_ce_narrow(img_rgb):
+    """
+    CE Identifier for scrolled down screenshot
+    """
+    height, width = img_rgb.shape[:2]
+    img = img_rgb[int(30/206*height):int(155/206*height),
+                  int(5/188*width):int(183/188*width)]
 
 ##    cv2.imshow("img", cv2.resize(img, dsize=None, fx=2., fy=2.))
 ##    cv2.waitKey(0)
@@ -647,6 +660,10 @@ def make_ce_data():
         out = ""
         for h in hash[0]:
             out = out + "{:02x}".format(h)
+        hash_narrow = compute_hash_ce_narrow(image)
+        out_narrow = ""
+        for h in hash_narrow[0]:
+            out_narrow = out_narrow + "{:02x}".format(h)
         tmp = {}
         tmp["id"] = ce["id"]
         tmp["type"] = "Craft Essence"
@@ -657,6 +674,7 @@ def make_ce_data():
         if name in shortname.keys():
             tmp["shortname"] = shortname[name]
         tmp["phash"]  = out
+        tmp["phash_narrow"]  = out_narrow
 #        tmp = [ce["id"]] + ["Craft Essence"] + [name] + [shortname[name] if name in shortname.keys() else "" ] + [out]
         ce_output[ce['rarity']].append(tmp)
 

--- a/update.py
+++ b/update.py
@@ -217,7 +217,7 @@ def compute_hash_ce(img_rgb):
     記述した比率はiPpd2018画像の実測値
     """
     height, width = img_rgb.shape[:2]
-    img = img_rgb[5:115,3:119]
+    img = img_rgb[19:115,3:119]
 
 ##    cv2.imshow("img", cv2.resize(img, dsize=None, fx=2., fy=2.))
 ##    cv2.waitKey(0)


### PR DESCRIPTION
In fgosccnt, add phash_narrow to the case where CE is scrolling and partially disappearing.
fgosccntで、概念礼装がスクロールして一部消えているケースにphash_narrow を加えて対応