### PR TITLE
logger.warning() に渡す引数の誤りを修正。

### DIFF
--- a/make_event_quest.py
+++ b/make_event_quest.py
@@ -50,8 +50,8 @@ def list2dic(quest_list):
         event_quest = FgoEventQuest(int(quest["id"]), quest["quest"],
                                     "", "", qp, drop, quest["shortname"])
         if quest["quest"] != spotname:
-            logger.warning("場所名が異なります: $s %s %s",
-                           infile, quest["quest"], spotname)
+            logger.warning("場所名が異なります: %s %s",
+                           quest["quest"], spotname)
         
         quest_output.append(dataclasses.asdict(event_quest))
     return quest_output


### PR DESCRIPTION
修正前のコードだと warning のログ出力を実行しようとして NameError が発生します。

```
Traceback (most recent call last):
  File "make_event_quest.py", line 94, in <module>
    main(args)
  File "make_event_quest.py", line 69, in main
    quest_dic = list2dic(quest_list)
  File "make_event_quest.py", line 54, in list2dic
    infile, quest["quest"], spotname)
NameError: name 'infile' is not defined
```