### PR TITLE
API 呼び出し失敗が明確に分かるようにする。

### DIFF
--- a/make_freequest.py
+++ b/make_freequest.py
@@ -40,6 +40,12 @@ for item in drop_item:
             alias2id[unicodedata.normalize('NFKC', a)] = item["id"]
 
 
+class APIError(Exception):
+    """
+    API 呼び出しが失敗したことを示すエラー
+    """
+
+
 @dataclasses.dataclass(frozen=True)
 class DropItem:
     """
@@ -69,7 +75,11 @@ class FgoFreeQuest(FgoQuest):
     scPriority: int
 
 def questId2quest(questId):
-    r_get = requests.get(url_quest + str(questId) + "/1")
+    endpoint = f"{url_quest}{questId}/1"
+    logger.info("calling HTTP API: %s", endpoint)
+    r_get = requests.get(endpoint)
+    if r_get.status_code != 200:
+        raise APIError(f"status code: {r_get.status_code}, text: {r_get.text}")
     quest = r_get.json()
     return quest
     


### PR DESCRIPTION
現状では `make_freequest.questId2quest()` の呼び出しが失敗しているかどうかに気づきにくい。

```
$ python3 make_event_quest.py data/csv/hunting_quest10.csv
Traceback (most recent call last):
  File "make_event_quest.py", line 94, in <module>
    main(args)
  File "make_event_quest.py", line 69, in main
    quest_dic = list2dic(quest_list)
  File "make_event_quest.py", line 47, in list2dic
    qp = q["qp"]
KeyError: 'qp'
```

このPRを適用すると API 呼び出し失敗時は以下のように `APIError` が raise されるため原因の特定がしやすくなる。

```
Python 3.8.5 (default, Jul 28 2020, 12:59:40)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import make_freequest
>>> make_freequest.questId2quest(123456789)
[INFO] calling HTTP API: https://api.atlasacademy.io/nice/JP/quest/123456789/1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/max747/ghq/github.com/fgosc/fgoscdata/make_freequest.py", line 82, in questId2quest
    raise APIError(f"status code: {r_get.status_code}, text: {r_get.text}")
make_freequest.APIError: status code: 404, text: {"detail":"Quest phase not found"}
>>>
```

成功時は今まで通り。

```
>>> r = make_freequest.questId2quest(94058407)
[INFO] calling HTTP API: https://api.atlasacademy.io/nice/JP/quest/94058407/1
>>> r.keys()
dict_keys(['id', 'name', 'type', 'consumeType', 'consume', 'consumeItem', 'spotId', 'warId', 'gifts', 'releaseConditions', 'phases', 'phasesWithEnemies', 'phasesNoBattle', 'noticeAt', 'openedAt', 'closedAt', 'phase', 'className', 'individuality', 'qp', 'exp', 'bond', 'scripts', 'messages', 'stages'])
```