### PR TITLE
add name_eng materials added in Avalon le Fae

### DIFF
--- a/hash_drop.json
+++ b/hash_drop.json
@@ -1320,6 +1320,7 @@
         "rarity": 2,
         "phash": "6f6ee69eda999bd9",
         "name": "夢幻の鱗粉",
+        "name_eng": "Scales of Phantasy",
         "shortname": "鱗粉",
         "dropPriority": 8319,
         "phash_battle": "6764269b99b99999"
@@ -1591,6 +1592,7 @@
         "rarity": 1,
         "phash": "64b39a486d640059",
         "name": "赦免の小鐘",
+        "name_eng": "Small Bells of Amnesty",
         "shortname": "小鐘",
         "dropPriority": 8106,
         "phash_battle": "269b486f22da4625"


### PR DESCRIPTION
--lang engオプションで鱗粉・小鐘が日本語のままになっていたため、アヴァロン・ル・フェで追加された素材のname_engを追加をしました。

before
![image](https://user-images.githubusercontent.com/6458565/131575332-94300c6f-4554-4162-8f3d-4475b1ed8f45.png)
after
![image](https://user-images.githubusercontent.com/6458565/131580058-2f7fd1e8-e97b-4534-ad0c-0695d26b9271.png)

name_engは [こちら](https://docs.google.com/spreadsheets/d/1_SlTjrVRTgHgfS7sRqx4CeJMqlz687HdSlYqiW-JvQA/htmlview#) から拝借しました。